### PR TITLE
Update LabelLayout.swift

### DIFF
--- a/Sources/Layouts/LabelLayout.swift
+++ b/Sources/Layouts/LabelLayout.swift
@@ -178,7 +178,7 @@ open class LabelLayout<Label: UILabel>: BaseLayout<Label>, ConfigurableLayout {
 
 public class LabelLayoutDefaults {
     public static let defaultNumberOfLines = 0
-    public static let defaultFont = UILabel().font ?? UIFont.systemFont(ofSize: 17)
+    public static let defaultFont = UIFont.systemFont(ofSize: 17)
     public static let defaultAlignment = Alignment.topLeading
     public static let defaultLineBreakMode = NSLineBreakMode.byTruncatingTail
     public static let defaultFlexibility = Flexibility.flexible

--- a/Sources/Views/ReloadableView.swift
+++ b/Sources/Views/ReloadableView.swift
@@ -15,7 +15,7 @@ import UIKit
 
  UITableView and UICollectionView conform to this protocol.
  */
-public protocol ReloadableView: class {
+public protocol ReloadableView: AnyObject {
 
     /// The bounds rectangle, which describes the view’s location and size in its own coordinate system.
     var bounds: CGRect { get }

--- a/Sources/Views/ReloadableViewUpdateManager.swift
+++ b/Sources/Views/ReloadableViewUpdateManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Delegate for a `ReloadableViewUpdateManager`.
-protocol ReloadableViewUpdateManagerDelegate: class {
+protocol ReloadableViewUpdateManagerDelegate: AnyObject {
     var reloadableView: ReloadableView? { get }
     var currentArrangement: [Section<[LayoutArrangement]>] { get set }
 }


### PR DESCRIPTION
UIFont.systemFont(ofSize: 17) IS the default font for UILabel, not sure why it was done this way, but this change is done to silence a runtime warning about not calling it on the main thread.